### PR TITLE
Usage example code fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ MyItemViewClass = Backbone.View.extend( {
 		// after we are done rendering, our subviews will automatically be rendered in order
 	},
 
-	_onSubviewsRendered : {
+	_onSubviewsRendered : function() {
 		// this method (if it exists) is called after subviews are finished rendering.
 		// anytime after subviews are rendered, you can find the subviews in the `subviews` hash
 


### PR DESCRIPTION
The readme had this code:

``` javascript
_onSubviewsRendered : {
```

but it was causing errors because it wasn't a method so I changed it to this:

``` javascript
_onSubviewsRendered : function() {
```

Tests are forthcoming and my progress on them is in my master branch which I will make a pull with once they are finished
